### PR TITLE
Support for Datastax 2.2 Cassandra Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Add a dependency to vertx-cassandra:
 </dependency>
 ```
 
-vert.x    | vertx-cassandra
---------- | ---------------
-3.0.0     | 3.0.0
-2.x       | 2.1.0 (vertx-mod-cassandra)
+vert.x    | cassandra | vertx-cassandra
+--------- | --------- | ---------------
+3.0.0     |   2.2     | 3.1.0
+3.0.0     |   2.1     | 3.0.0
+2.x       |   2.1     | 2.1.0 (vertx-mod-cassandra)
 
 ## Configuration
 The main configuration is via the normal config.json file for a Vert.x module. 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </parent>
 
     <properties>
-        <cassandra.driver.version>2.1.6</cassandra.driver.version>
+        <cassandra.driver.version>2.2.0-rc3</cassandra.driver.version>
         <vertx.version>3.0.0</vertx.version>
         <vertx.hk2.version>2.0.0</vertx.hk2.version>
         <vertx.guice.version>2.0.0</vertx.guice.version>

--- a/vertx-cassandra-mapping/src/test/java/com/englishtown/vertx/cassandra/mapping/impl/DefaultVertxMapperTest.java
+++ b/vertx-cassandra-mapping/src/test/java/com/englishtown/vertx/cassandra/mapping/impl/DefaultVertxMapperTest.java
@@ -8,6 +8,7 @@ import io.vertx.core.Vertx;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -47,6 +48,7 @@ public class DefaultVertxMapperTest {
         when(rawMapper.saveAsync(eq(entity))).thenReturn(voidFuture);
         when(rawMapper.deleteAsync(eq(entity))).thenReturn(voidFuture);
         when(rawMapper.deleteAsync(any(), any())).thenReturn(voidFuture);
+        when(rawMapper.deleteAsync(Matchers.<Object>anyVararg())).thenReturn(voidFuture);
         when(rawMapper.getAsync(any(), any())).thenReturn(entityFuture);
 
     }

--- a/vertx-cassandra-mapping/src/test/java/com/englishtown/vertx/cassandra/mapping/impl/DefaultVertxMappingManagerTest.java
+++ b/vertx-cassandra-mapping/src/test/java/com/englishtown/vertx/cassandra/mapping/impl/DefaultVertxMappingManagerTest.java
@@ -45,7 +45,7 @@ public class DefaultVertxMappingManagerTest {
         when(metadata.getKeyspace(anyString())).thenReturn(keyspaceMetadata);
         when(cluster.getConfiguration()).thenReturn(configuration);
         when(configuration.getProtocolOptions()).thenReturn(protocolOptions);
-        when(protocolOptions.getProtocolVersionEnum()).thenReturn(ProtocolVersion.NEWEST_SUPPORTED);
+        when(protocolOptions.getProtocolVersion()).thenReturn(ProtocolVersion.NEWEST_SUPPORTED);
 
         manager = new DefaultVertxMappingManager(session);
 

--- a/vertx-cassandra/src/main/java/com/englishtown/vertx/cassandra/impl/DefaultCassandraSession.java
+++ b/vertx-cassandra/src/main/java/com/englishtown/vertx/cassandra/impl/DefaultCassandraSession.java
@@ -297,6 +297,16 @@ public class DefaultCassandraSession implements CassandraSession {
         return getSession().prepare(statement);
     }
 
+    @Override
+    public SimpleStatement newSimpleStatement(String s) {
+        return getSession().newSimpleStatement(s);
+    }
+
+    @Override
+    public SimpleStatement newSimpleStatement(String s, Object... objects) {
+        return getSession().newSimpleStatement(s, objects);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/vertx-cassandra/src/main/java/com/englishtown/vertx/cassandra/impl/Metrics.java
+++ b/vertx-cassandra/src/main/java/com/englishtown/vertx/cassandra/impl/Metrics.java
@@ -255,10 +255,6 @@ class Metrics implements AutoCloseable {
             downHosts.remove(key);
         }
 
-        @Override
-        public void onSuspected(Host host) {
-        }
-
         /**
          * Called when a node is determined to be down.
          *
@@ -281,6 +277,14 @@ class Metrics implements AutoCloseable {
             String key = getKey(host);
             removedHosts.put(key, host);
             addedHosts.remove(key);
+        }
+
+        @Override
+        public void onRegister(Cluster cluster) {
+        }
+
+        @Override
+        public void onUnregister(Cluster cluster) {
         }
     }
 }

--- a/vertx-cassandra/src/main/java/com/englishtown/vertx/cassandra/keyspacebuilder/BuiltKeyspaceStatement.java
+++ b/vertx-cassandra/src/main/java/com/englishtown/vertx/cassandra/keyspacebuilder/BuiltKeyspaceStatement.java
@@ -35,7 +35,7 @@ public abstract class BuiltKeyspaceStatement extends RegularStatement {
      * {@inheritDoc}
      */
     @Override
-    public ByteBuffer[] getValues(ProtocolVersion protocolVersion) {
+    public ByteBuffer[] getValues() {
         return null;
     }
 

--- a/vertx-cassandra/src/main/java/com/englishtown/vertx/cassandra/tablebuilder/BuiltTableStatement.java
+++ b/vertx-cassandra/src/main/java/com/englishtown/vertx/cassandra/tablebuilder/BuiltTableStatement.java
@@ -37,7 +37,7 @@ public abstract class BuiltTableStatement extends RegularStatement {
      * {@inheritDoc}
      */
     @Override
-    public ByteBuffer[] getValues(ProtocolVersion protocolVersion) {
+    public ByteBuffer[] getValues() {
         return null;
     }
 

--- a/vertx-cassandra/src/test/java/com/englishtown/vertx/cassandra/impl/DefaultCassandraSessionTest.java
+++ b/vertx-cassandra/src/test/java/com/englishtown/vertx/cassandra/impl/DefaultCassandraSessionTest.java
@@ -34,7 +34,7 @@ public class DefaultCassandraSessionTest {
 
     DefaultCassandraSession cassandraSession;
     List<String> seeds = new ArrayList<>();
-    Configuration configuration = new Configuration();
+    Configuration configuration = Configuration.builder().build();
 
     @Mock
     Vertx vertx;
@@ -95,15 +95,16 @@ public class DefaultCassandraSessionTest {
         }
 
         @Override
-        public void onSuspected(Host host) {
-        }
-
-        @Override
         public void onDown(Host host) {
         }
 
         @Override
         public void onRemove(Host host) {
+        }
+
+        @Override
+        public void close() {
+
         }
     }
 
@@ -234,7 +235,7 @@ public class DefaultCassandraSessionTest {
 
     @Test
     public void testPrepareAsync_Statement() throws Exception {
-        RegularStatement statement = QueryBuilder
+        RegularStatement statement = new QueryBuilder(ProtocolVersion.V4, CodecRegistry.DEFAULT_INSTANCE)
                 .select()
                 .from("ks", "table")
                 .where(QueryBuilder.eq("id", QueryBuilder.bindMarker()));
@@ -254,7 +255,7 @@ public class DefaultCassandraSessionTest {
 
     @Test
     public void testPrepare_Statement() throws Exception {
-        RegularStatement statement = QueryBuilder
+        RegularStatement statement = new QueryBuilder(ProtocolVersion.V4, CodecRegistry.DEFAULT_INSTANCE)
                 .select()
                 .from("ks", "table")
                 .where(QueryBuilder.eq("id", QueryBuilder.bindMarker()));

--- a/vertx-cassandra/src/test/java/com/englishtown/vertx/cassandra/impl/JsonCassandraConfiguratorTest.java
+++ b/vertx-cassandra/src/test/java/com/englishtown/vertx/cassandra/impl/JsonCassandraConfiguratorTest.java
@@ -55,15 +55,16 @@ public class JsonCassandraConfiguratorTest {
         }
 
         @Override
-        public void onSuspected(Host host) {
-        }
-
-        @Override
         public void onDown(Host host) {
         }
 
         @Override
         public void onRemove(Host host) {
+        }
+
+        @Override
+        public void close() {
+
         }
     }
 
@@ -71,6 +72,16 @@ public class JsonCassandraConfiguratorTest {
         @Override
         public ReconnectionSchedule newSchedule() {
             return null;
+        }
+
+        @Override
+        public void init(Cluster cluster) {
+
+        }
+
+        @Override
+        public void close() {
+
         }
     }
 

--- a/vertx-cassandra/src/test/java/com/englishtown/vertx/cassandra/integration/CassandraSessionIntegrationTest.java
+++ b/vertx-cassandra/src/test/java/com/englishtown/vertx/cassandra/integration/CassandraSessionIntegrationTest.java
@@ -1,7 +1,9 @@
 package com.englishtown.vertx.cassandra.integration;
 
 import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
@@ -19,7 +21,7 @@ public abstract class CassandraSessionIntegrationTest extends IntegrationTestBas
 
         session.execute(createTestTableStatement);
 
-        RegularStatement statement = QueryBuilder
+        RegularStatement statement = new QueryBuilder(ProtocolVersion.V4, CodecRegistry.DEFAULT_INSTANCE)
                 .select()
                 .from(keyspace, "test")
                 .where(QueryBuilder.eq("id", QueryBuilder.bindMarker()));


### PR DESCRIPTION
The 2.2 datastax driver is incompatible with version 3.0.0 of this project. There are some changes being made (mainly Codecs) and some deprecated code that has been removed in 2.2.
See http://datastax.github.io/java-driver/upgrade_guide/index.html